### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const App = () => {
           justifyContent: 'center',
           alignItems: 'center',
           backgroundColor: 'red',
-          borderRadius: '50%',
+          borderRadius: 50,
           width: '100%',
         }}><Text>🤓</Text></View>}
         style={{ backgroundColor: 'white' }}


### PR DESCRIPTION
In the first example, borderRadius value is given in string format and as a percentage value in the View tag of FancyAlert icon parameter. But this gives an error. According to the ReactNative documents, the borderRadius value must be in number format.